### PR TITLE
feat: add DR Nordjylland regional RSS feed for Aalborg coverage

### DIFF
--- a/ingestion/config.py
+++ b/ingestion/config.py
@@ -38,8 +38,9 @@ Recent Additions (2025-10-15):
   * International: 1 wire service (Guardian World) ✅
   * UK/Ireland: 2 sources (Irish Times, Sky News UK) ✅
   * Removed: Janes Defence (paywall), Reuters Europe (auth required)
-- Total working sources: 88 RSS feeds + 3 HTML scrapers (91 total sources)
+- Total working sources: 89 RSS feeds + 3 HTML scrapers (92 total sources)
 - Geographic Coverage: Matches CEPA map (all Baltic + Nordic + Western Europe)
+- Latest addition: DR Nordjylland regional feed (2025-11-17)
 """
 
 import os
@@ -66,6 +67,17 @@ SOURCES = {
         "keywords": ["drone", "dron", "lufthavn", "forsvar", "uav"],
         "verified_date": "2025-10-05",
         "working": True
+    },
+
+    "dr_nordjylland": {
+        "name": "DR Nordjylland (Regional)",
+        "rss": "https://www.dr.dk/nyheder/service/feeds/regionale/nord",
+        "source_type": "verified_media",
+        "trust_weight": 3,
+        "keywords": ["drone", "dron", "aalborg", "nordjylland", "lufthavn", "uav"],
+        "verified_date": "2025-11-17",
+        "working": True,
+        "note": "Regional coverage for Northern Jutland including Aalborg Airport"
     },
 
     "tv2_lorry": {


### PR DESCRIPTION
Added DR Nordjylland (Northern Jutland) regional news feed to improve coverage of drone incidents in the Aalborg area.

Changes:
- Added dr_nordjylland source to config.py
- Source type: verified_media (trust_weight: 3)
- RSS URL: https://www.dr.dk/nyheder/service/feeds/regionale/nord
- Keywords: drone, dron, aalborg, nordjylland, lufthavn, uav
- Updated total source count: 89 RSS feeds + 3 HTML (92 total)

Why:
- User reported Aalborg Airport drone incident not appearing
- DR Nordjylland provides regional coverage for Northern Jutland
- Complements existing dr_news (national) and tv2_nord (regional TV)
- Regional feeds often have faster/more detailed local incident coverage

Expected Impact:
- Better coverage of Northern Jutland drone incidents
- Faster detection of Aalborg Airport incidents
- Higher quality regional reporting from DR (public broadcaster)